### PR TITLE
Add code coverage report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ fetch/resources:
 #
 #   make test
 #
-test: dependencies/resources dependencies/services test/run dependencies/clean/services
+test: dependencies/resources dependencies/services test/run test/coverage dependencies/clean/services
 
 # Compile project with test folder included
 #
@@ -88,6 +88,20 @@ test/compile: dependencies/resources
 #
 test/run:
 	$(_sbt-cmd-with-dependencies) test
+
+# Run coverage analysis and reports
+#
+#   make test/coverage
+#
+test/coverage:
+	$(_sbt-cmd) coverage coverageReport
+
+# Send coverate reports to Coveralls
+#
+#   make test/coveralls
+#
+test/coveralls:
+	$(_sbt-cmd) coverageAggregate coveralls
 
 # Configure gcloud tool to be used by circleci
 #   make circleci/gcloud/setup

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Geladinha
 
 ![Build Status](https://circleci.com/gh/nykolaslima/geladinha.svg?&style=shield)
+![Coverage Status](https://coveralls.io/repos/github/nykolaslima/geladinha/badge.svg?branch=master)
 
 This application aim to provide a sample application implementing a REST API with Akka technology.  
 The endpoints support JSON and binary Protobuf protocols with Swagger as documentation tool.  

--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,8 @@ parallelExecution in ThisBuild := false
 
 enablePlugins(JavaAppPackaging)
 
+coverageEnabled := true
+
 unmanagedSourceDirectories in Compile += baseDirectory.value / "src/main/generated-proto"
 
 val akkaV = "2.4.16"

--- a/circle.yml
+++ b/circle.yml
@@ -24,3 +24,4 @@ test:
   override:
     - sudo service postgresql stop
     - make test
+    - make test/coveralls

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,7 @@
 logLevel := Level.Warn
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.5")
+
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
+
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")


### PR DESCRIPTION
Add coverage report using [Coveralls](https://coveralls.io/). Using
default coverage configurations that could be improved to ignore some
files that doesn't need to be tested.