### PR TITLE
Fix Coveralls report upload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ fetch/resources:
 #
 #   make test
 #
-test: dependencies/resources dependencies/services test/run test/coverage dependencies/clean/services
+test: dependencies/resources dependencies/services test/run dependencies/clean/services
 
 # Compile project with test folder included
 #
@@ -87,14 +87,7 @@ test/compile: dependencies/resources
 #   make test/run
 #
 test/run:
-	$(_sbt-cmd-with-dependencies) test
-
-# Run coverage analysis and reports
-#
-#   make test/coverage
-#
-test/coverage:
-	$(_sbt-cmd) coverage coverageReport
+	$(_sbt-cmd-with-dependencies) coverage test coverageReport
 
 # Send coverate reports to Coveralls
 #

--- a/circle.yml
+++ b/circle.yml
@@ -13,6 +13,10 @@ machine:
     PROJECT_NAME: "api"
     CLUSTER_NAME: "api-cluster"
     CLOUDSDK_COMPUTE_ZONE: "us-east1-d"
+    COVERALLS_REPO_TOKEN: ${COVERALLS_REPO_TOKEN}
+    COVERALLS_SERVICE_JOB_ID: ${CIRCLE_BUILD_NUM}
+    COVERALLS_SERVICE_NAME: CircleCI
+    TRAVIS_JOB_ID: ${CIRCLE_BUILD_NUM}
 dependencies:
   cache_directories:
     - "~/.m2"
@@ -23,5 +27,6 @@ dependencies:
 test:
   override:
     - sudo service postgresql stop
+    - while sudo lsof -Pi :5432 -sTCP:LISTEN -t; do sleep 1; done
     - make test
     - make test/coveralls


### PR DESCRIPTION
We need to especify the job id with the repo token in order to upload
the coverage reports to Coveralls.