### PR TITLE
Remove Coveralls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,13 +96,6 @@ test/run:
 test/coverage:
 	$(_sbt-cmd) coverage coverageReport
 
-# Send coverate reports to Coveralls
-#
-#   make test/coveralls
-#
-test/coveralls:
-	$(_sbt-cmd) coverageAggregate coveralls
-
 # Configure gcloud tool to be used by circleci
 #   make circleci/gcloud/setup
 #

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Geladinha
 
 ![Build Status](https://circleci.com/gh/nykolaslima/geladinha.svg?&style=shield)
-![Coverage Status](https://coveralls.io/repos/github/nykolaslima/geladinha/badge.svg?branch=master)
 
 This application aim to provide a sample application implementing a REST API with Akka technology.  
 The endpoints support JSON and binary Protobuf protocols with Swagger as documentation tool.  

--- a/circle.yml
+++ b/circle.yml
@@ -24,4 +24,3 @@ test:
   override:
     - sudo service postgresql stop
     - make test
-    - make test/coveralls

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,5 +3,3 @@ logLevel := Level.Warn
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.5")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
-
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")


### PR DESCRIPTION
The plugin isn't working with CircleCI so we're removing the Coveralls
for now and only keep the coverage reports locally.