### PR TITLE
Support GeoJSON as Point and MultiPolygon messages

### DIFF
--- a/src/main/scala/com/zxventures/geladinha/infrastructure/serialization/ApplicationMarshalling.scala
+++ b/src/main/scala/com/zxventures/geladinha/infrastructure/serialization/ApplicationMarshalling.scala
@@ -7,20 +7,26 @@ import akka.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeExcep
 import akka.http.scaladsl.unmarshalling.{Unmarshaller, _}
 import akka.http.scaladsl.util.FastFuture
 import com.google.protobuf.CodedInputStream
-import com.trueaccord.scalapb.json.JsonFormat
+import com.trueaccord.scalapb.json.{JsonFormat, Parser, Printer}
 import com.trueaccord.scalapb.{GeneratedMessage, GeneratedMessageCompanion, Message}
+import com.zxventures.geladinha.resources.geometry.{MultiPolygon, Point}
 
 import scala.concurrent.Future
 
 trait ApplicationMarshalling {
   private val protobufContentType = ContentType(MediaType.applicationBinary("x-protobuf", Compressible, "proto"))
   private val applicationJsonContentType = ContentTypes.`application/json`
+  private val registry = JsonFormat.DefaultRegistry
+    .registerWriter[Point](GeoJsonMarshalling.pointWriter, GeoJsonMarshalling.pointParser)
+    .registerWriter[MultiPolygon](GeoJsonMarshalling.multiPolygonWriter, GeoJsonMarshalling.multiPolygonParser)
+  private val printer = new Printer(formatRegistry = registry)
+  private val parser = new Parser(formatRegistry = registry)
 
   def scalaPBFromRequestUnmarshaller[O <: GeneratedMessage with Message[O]](companion: GeneratedMessageCompanion[O]): FromEntityUnmarshaller[O] = {
     Unmarshaller.withMaterializer[HttpEntity, O](_ ⇒ implicit mat ⇒ {
       case entity@HttpEntity.Strict(`applicationJsonContentType`, data) ⇒
         val charBuffer = Unmarshaller.bestUnmarshallingCharsetFor(entity)
-        FastFuture.successful(JsonFormat.fromJsonString(data.decodeString(charBuffer.nioCharset().name()))(companion))
+        FastFuture.successful(parser.fromJsonString(data.decodeString(charBuffer.nioCharset().name()))(companion))
       case entity@HttpEntity.Strict(`protobufContentType`, data) ⇒
         FastFuture.successful(companion.parseFrom(CodedInputStream.newInstance(data.asByteBuffer)))
       case entity ⇒
@@ -32,7 +38,7 @@ trait ApplicationMarshalling {
     def jsonMarshaller(): ToEntityMarshaller[U] = {
       val contentType = applicationJsonContentType
       Marshaller.withFixedContentType(contentType) { value ⇒
-        HttpEntity(contentType, JsonFormat.toJsonString(value))
+        HttpEntity(contentType, printer.print(value))
       }
     }
 

--- a/src/main/scala/com/zxventures/geladinha/infrastructure/serialization/GeoJsonMarshalling.scala
+++ b/src/main/scala/com/zxventures/geladinha/infrastructure/serialization/GeoJsonMarshalling.scala
@@ -1,0 +1,78 @@
+package com.zxventures.geladinha.infrastructure.serialization
+
+import com.zxventures.geladinha.resources.geometry.{LinearString, MultiPolygon, Point, Polygon}
+import org.json4s.JValue
+import org.json4s.JsonAST._
+
+object GeoJsonMarshalling {
+  def pointWriter: (Point => JValue) = {
+    (point) => JObject(
+      List(
+        "type" -> JString("Point"),
+        "coordinates" -> JArray(List(JDecimal(BigDecimal(point.longitude.toString)), JDecimal(BigDecimal(point.latitude.toString))))
+      )
+    )
+  }
+
+  def pointParser: (JValue => Point) = {
+    import org.json4s._
+    (jv) => {
+      val longitude: Float = (jv \\ "coordinates").asInstanceOf[JArray].values(0).asInstanceOf[Double].toFloat
+      val latitude: Float = (jv \\ "coordinates").asInstanceOf[JArray].values(1).asInstanceOf[Double].toFloat
+      Point(latitude, longitude)
+    }
+  }
+
+  def multiPolygonWriter: (MultiPolygon => JValue) = {
+    (multiPolygon) => JObject(
+      List(
+        "type" -> JString("MultiPolygon"),
+        "coordinates" -> encodeJson(multiPolygonAsListOfLists(multiPolygon))
+      )
+    )
+  }
+
+  def multiPolygonParser: (JValue => MultiPolygon) = {
+    import org.json4s._
+    (jv) => {
+      val polygons = (jv \\ "coordinates").asInstanceOf[JArray].arr.map { valuePolygon =>
+        val linearStrings: List[LinearString] = valuePolygon.asInstanceOf[JArray].arr.map { valueLinerString =>
+          val points: List[Point] = valueLinerString.asInstanceOf[JArray].arr.map { valuePositions =>
+            val longitude = valuePositions.asInstanceOf[JArray].values(0).asInstanceOf[Double].toFloat
+            val latitude = valuePositions.asInstanceOf[JArray].values(1).asInstanceOf[Double].toFloat
+
+            Point(latitude, longitude)
+          }
+
+          LinearString(points)
+        }
+
+        Polygon(linearStrings)
+      }
+
+      MultiPolygon(polygons)
+    }
+  }
+
+  private def multiPolygonAsListOfLists(mp: MultiPolygon): Seq[Seq[Seq[Seq[BigDecimal]]]] = {
+    mp.polygons.map { p =>
+      val linerStringsCoordinates = p.linearStrings.map { lr =>
+        lr.points.map { p =>
+          Seq(BigDecimal(p.longitude.toString), BigDecimal(p.latitude.toString))
+        }
+      }
+
+      if(linerStringsCoordinates.size > 1) throw new UnsupportedOperationException("Polygon with exterior rings are not supported because we are using Earth as our exterior ring (https://tools.ietf.org/html/rfc7946#appendix-A.3)")
+
+      linerStringsCoordinates
+    }
+  }
+
+  private def encodeJson(src: AnyRef): JValue = {
+    import org.json4s.jackson.Serialization
+    import org.json4s.{Extraction, NoTypeHints}
+    implicit val formats = Serialization.formats(NoTypeHints)
+
+    Extraction.decompose(src)
+  }
+}

--- a/src/test/scala/com/zxventures/geladinha/infrastructure/generators/pointOfSale/PointOfSaleGenerator.scala
+++ b/src/test/scala/com/zxventures/geladinha/infrastructure/generators/pointOfSale/PointOfSaleGenerator.scala
@@ -10,7 +10,7 @@ import org.scalacheck.Gen._
 trait PointOfSaleGenerator extends GeneratorUtil {
 
   val geom = new GeometryFactory()
-  private val polygonPoints = List(
+  val polygonPoints = List(
     PointResource(
       latitude = -23.53560255279179f,
       longitude = -46.7936897277832f
@@ -24,8 +24,8 @@ trait PointOfSaleGenerator extends GeneratorUtil {
       longitude = -46.77781105041503f
     ),
     PointResource(
-      latitude = -46.77856206893921f,
-      longitude = -23.537530458746964f
+      latitude = -23.537530458746964f,
+      longitude = -46.77856206893921f
     ),
     PointResource(
       latitude = -23.52997605345957f,

--- a/src/test/scala/com/zxventures/geladinha/infrastructure/serialization/GeoJsonMarshallingSpec.scala
+++ b/src/test/scala/com/zxventures/geladinha/infrastructure/serialization/GeoJsonMarshallingSpec.scala
@@ -1,0 +1,58 @@
+package com.zxventures.geladinha.infrastructure.serialization
+
+import com.trueaccord.scalapb.json.{JsonFormat, Parser, Printer}
+import com.zxventures.geladinha.infrastructure.generators.pointOfSale.PointOfSaleGenerator
+import com.zxventures.geladinha.infrastructure.test.UnitSpec
+import com.zxventures.geladinha.resources.geometry.{MultiPolygon, Point}
+
+class GeoJsonMarshallingSpec extends UnitSpec with PointOfSaleGenerator {
+  "toJson" when {
+    "Point message" must {
+      "generate JSON in GeoJSON format" in {
+        val point = pointOfSaleResourceGen.sample.get.address.get
+
+        val registry = JsonFormat.DefaultRegistry
+          .registerWriter[Point](GeoJsonMarshalling.pointWriter, GeoJsonMarshalling.pointParser)
+
+        new Printer(formatRegistry = registry).print(point) shouldEqual
+          s"""{"type":"Point","coordinates":[${point.longitude},${point.latitude}]}"""
+      }
+    }
+
+    "MultiPolygon message" must {
+      "generate JSON in GeoJSON format" in {
+        val multiPolygon = pointOfSaleResourceGen.sample.get.coverageArea.get
+
+        val registry = JsonFormat.DefaultRegistry
+          .registerWriter[MultiPolygon](GeoJsonMarshalling.multiPolygonWriter, GeoJsonMarshalling.multiPolygonParser)
+
+        new Printer(formatRegistry = registry).print(multiPolygon) shouldEqual
+          s"""{"type":"MultiPolygon","coordinates":[[[[${polygonPoints(0).longitude},${polygonPoints(0).latitude}],[${polygonPoints(1).longitude},${polygonPoints(1).latitude}],[${polygonPoints(2).longitude},${polygonPoints(2).latitude}],[${polygonPoints(3).longitude},${polygonPoints(3).latitude}],[${polygonPoints(4).longitude},${polygonPoints(4).latitude}],[${polygonPoints(5).longitude},${polygonPoints(5).latitude}]]]]}"""
+      }
+    }
+  }
+
+  "fromJson" when {
+    "Point GeoJSON" must {
+      "generate Point message" in {
+        val point = pointOfSaleResourceGen.sample.get.address.get
+
+        val registry = JsonFormat.DefaultRegistry
+          .registerWriter[Point](GeoJsonMarshalling.pointWriter, GeoJsonMarshalling.pointParser)
+
+        new Parser(formatRegistry = registry).fromJsonString[Point](s"""{"type":"Point","coordinates":[${point.longitude},${point.latitude}]}""") shouldEqual point
+      }
+    }
+
+    "MultiPolygon GeoJSON" must {
+      "generate MultiPolygon message" in {
+        val multiPolygon = pointOfSaleResourceGen.sample.get.coverageArea.get
+
+        val registry = JsonFormat.DefaultRegistry
+          .registerWriter[MultiPolygon](GeoJsonMarshalling.multiPolygonWriter, GeoJsonMarshalling.multiPolygonParser)
+
+        new Parser(formatRegistry = registry).fromJsonString[MultiPolygon](s"""{"type":"MultiPolygon","coordinates":[[[[-46.7936897277832,-23.53560255279179],[-46.78783178329468,-23.54185830797095],[-46.77781105041503,-23.54059931197617],[-46.77856206893921,-23.537530458746964],[-46.78401231765747,-23.52997605345957],[-46.7936897277832,-23.53560255279179]]]]}""") shouldEqual multiPolygon
+      }
+    }
+  }
+}


### PR DESCRIPTION
The Protobuf definition of Point and MultiPolygon messages doesn't
generate a JSON compliant with GeoJSON specification. This code add
custom JSON serializers to Point and MultiPolygon in order to make it
compliant with GeoJSON specification.