### PR TITLE
Fix /points-of-sale endpoints and properties name in Swagger docs

### DIFF
--- a/src/main/resources/api-docs/paths.json
+++ b/src/main/resources/api-docs/paths.json
@@ -45,6 +45,52 @@
             }
           }
         }
+      },
+      "get": {
+        "tags": [
+          "Public"
+        ],
+        "summary": "List points of sale by some filters",
+        "description": "Given the filters, list points of sale",
+        "operationId": "ListPointOfSale",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "latitude",
+            "in": "query",
+            "description": "Latitude of the address to filter points of sale by coverage area",
+            "required": true,
+            "type": "number",
+            "format": "float"
+          },
+          {
+            "name": "longitude",
+            "in": "query",
+            "description": "Longitude of the address to filter points of sale by coverage area",
+            "required": true,
+            "type": "number",
+            "format": "float"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Found points of sale",
+            "schema": {
+              "$ref": "#/definitions/PointsOfSale"
+            }
+          },
+          "500": {
+            "description": "Unexpected error happened",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
       }
     },
     "/points-of-sale/{id}": {
@@ -82,54 +128,6 @@
             "description": "No point of sale found",
             "schema": {
               "$ref": "#/definitions/Messages"
-            }
-          },
-          "500": {
-            "description": "Unexpected error happened",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          }
-        }
-      }
-    },
-    "/points-of-sale": {
-      "get": {
-        "tags": [
-          "Public"
-        ],
-        "summary": "List points of sale by some filters",
-        "description": "Given the filters, list points of sale",
-        "operationId": "ListPointOfSale",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "parameters": [
-          {
-            "name": "latitude",
-            "in": "query",
-            "description": "Latitude of the address to filter points of sale by coverage area",
-            "required": true,
-            "type": "number",
-            "format": "float"
-          },
-          {
-            "name": "longitude",
-            "in": "query",
-            "description": "Longitude of the address to filter points of sale by coverage area",
-            "required": true,
-            "type": "number",
-            "format": "float"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Found points of sale",
-            "schema": {
-              "$ref": "#/definitions/PointsOfSale"
             }
           },
           "500": {

--- a/src/main/scala/com/zxventures/geladinha/components/swagger/SwaggerDocs.scala
+++ b/src/main/scala/com/zxventures/geladinha/components/swagger/SwaggerDocs.scala
@@ -110,7 +110,7 @@ object SwaggerDocs {
 
     def fields(descriptor: Descriptor) = {
       descriptor.getFields.toArray.asInstanceOf[Array[FieldDescriptor]]
-        .foldLeft(Map[String, Any]()) { (a, b) => Map(b.getName -> fieldDetails(b)) ++ a }
+        .foldLeft(Map[String, Any]()) { (a, b) => Map(underscoreToCamel(b.getName) -> fieldDetails(b)) ++ a }
     }
 
     val resourcesToGenerate = _resources.filter { resource =>
@@ -184,4 +184,8 @@ object SwaggerDocs {
       "host" -> config.getString("swagger.host")
     )
   }
+
+  private def underscoreToCamel(name: String) = "_([a-z\\d])".r.replaceAllIn(name, {m =>
+    m.group(1).toUpperCase()
+  })
 }


### PR DESCRIPTION
The /points-of-sale endpoints should be grouped inside same path with
different http method entries.

Fix the attributes case transforming from snake case Proto message
definitions to camel case, since the generate classes and JSON uses
camel case for attribute names.