### PR TITLE
Create start task for development environment [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The endpoints support JSON and binary Protobuf protocols with Swagger as documen
 
 - Tools
   - [Circle CI](https://circleci.com/gh/nykolaslima/geladinha),
-  - Swagger: [localhost](http://localhost:9090/api-docs/)
+  - Swagger: [localhost](http://localhost:8080/api-docs/)
 
 ## Requirements
 
@@ -22,6 +22,8 @@ day-to-day task when developing and deploying an application.
 
 ### Tasks
 
+- `make start/development`: Start application on local development environment.
+- `make start/clean/development`: Clean started development application dependencies.
 - `make build`: Build a self-contained jar with all dependencies included.
 - `make image`: Build a Docker image with the latest tag (implicates `build`).
 - `make image/publish`: Publishes the built image (implicates `build` and `image`).
@@ -34,12 +36,15 @@ day-to-day task when developing and deploying an application.
 
 ### Running the application
 
-The docker image defines an entrypoint ready to run and optionally pass custom args:
+We can run application on development environment through on demand generated application docker image 
+using local docker-compose dependencies.
 
 ```sh
-docker run \
-  -p 9090:9090 \
-  -e environment=test \
-  zxventures/geladinha:latest \
-  -Dakka.loglevel=WARN
+make start/development
+```
+
+In order to clean `start/development` dependencies just run:
+
+```sh
+make start/clean/development
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -8,8 +8,6 @@ parallelExecution in ThisBuild := false
 
 enablePlugins(JavaAppPackaging)
 
-coverageEnabled := true
-
 unmanagedSourceDirectories in Compile += baseDirectory.value / "src/main/generated-proto"
 
 val akkaV = "2.4.16"

--- a/src/main/resources/development.conf
+++ b/src/main/resources/development.conf
@@ -1,0 +1,19 @@
+http {
+  interface = "0.0.0.0"
+  port = 8080
+}
+
+database.postgres {
+  dataSourceClass = "slick.jdbc.DatabaseUrlDataSource"
+  properties = {
+    driver = "slick.driver.PostgresDriver$"
+    url = "postgres://postgres:postgres@postgres:5432/geladinha"
+  }
+  minConnections = 5
+  maxConnections = 20
+  connectionTimeout = 3000
+}
+
+swagger {
+  host = "localhost:8080"
+}


### PR DESCRIPTION
`make start/development` task will setup a local environment and run the
current local application on development environment.

`make start/clean/development` task will teardown started dependencies,
such as databases.